### PR TITLE
Fix dust package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,10 +72,10 @@ cargo install difftastic
 ### dust
 
 Show disk usage. Like `du` and more intuitive. Mnemonic: du + rust = dust.
-* https://crates.io/crates/dust
+* https://crates.io/crates/du-dust
 * https://github.com/bootandy/dust
 ```sh
-cargo install dust
+cargo install du-dust
 ```
 
 ### eza


### PR DESCRIPTION
Love your list!

Noticed that the package name for `dust` is incorrect in the readme (it's correct in the `bin/install` script). `dust` points to a package for data driven tests, while the correct package name on crates.io is `du-dust`.